### PR TITLE
Mcts benchmark

### DIFF
--- a/src/benchmark.jl
+++ b/src/benchmark.jl
@@ -130,15 +130,19 @@ end
 Pure MCTS baseline that uses rollouts to evaluate new positions.
 
 Argument `params` has type [`MctsParams`](@ref).
+Additionally, a depth can be provided to define the maximum number of rollout steps before calling heuristic_value.
+If depth == 0, there will be no rollout at all and heuristic_value is called immediately.
 """
 struct MctsRollouts <: Player
   params :: MctsParams
+  depth :: Union{Int, Float64} # Inf isa Float64
+  MctsRollouts(params::MctsParams, depth=Inf) = new(params, max(zero(depth), depth))
 end
 
-name(p::MctsRollouts) = "MCTS ($(p.params.num_iters_per_turn) rollouts)"
+name(p::MctsRollouts) = "MCTS ($(p.params.num_iters_per_turn) rollouts, depth $(p.depth))"
 
 function instantiate(p::MctsRollouts, gspec::AbstractGameSpec, nn)
-  return MctsPlayer(gspec, MCTS.RolloutOracle(gspec), p.params)
+  return MctsPlayer(gspec, MCTS.RolloutOracle(gspec, p.depth), p.params)
 end
 
 """

--- a/src/mcts.jl
+++ b/src/mcts.jl
@@ -39,13 +39,13 @@ struct RolloutOracle{GameSpec} <: Function
 end
 
 function rollout!(game, γ=1.)
-  r = 0.
-  while !GI.game_terminated(game)
-    action = rand(GI.available_actions(game))
-    GI.play!(game, action)
-    r = γ * r + GI.white_reward(game)
-  end
-  return r
+  action = rand(GI.available_actions(game))
+  GI.play!(game, action)
+  wr = GI.white_reward(game)
+  if GI.game_terminated(game)
+    return wr
+  else
+    return wr + γ * rollout!(game, γ)
 end
 
 function (r::RolloutOracle)(state)


### PR DESCRIPTION
I wanted to add the possibility of stopping `rollout!` at some depth and use `heuristic_value` the estimate the remainder.
When doing this, I stumbled across what I presume to be an error (which is fixed in the first commit). I think with the current implementation discounting of rewards is computed wrongly: The first rewards are the ones that are discounted the highest whereas the last reward of the rollout is not discounted. I think it should be the other way round.