### PR TITLE
Adaptive normalization for unknown reward sizes

### DIFF
--- a/games/grid-world/params.jl
+++ b/games/grid-world/params.jl
@@ -16,10 +16,11 @@ self_play = SelfPlayParams(
     alternate_colors=false),
   mcts=MctsParams(
     num_iters_per_turn=50,
-    cpuct=1.0,
+    cpuct=1.5,
     temperature=ConstSchedule(0.),
     dirichlet_noise_ϵ=0.,
-    dirichlet_noise_α=1.))
+    dirichlet_noise_α=1.,
+    adaptive_normalization=true))
 
 arena = ArenaParams(
   sim=SimParams(
@@ -37,7 +38,6 @@ learning = LearningParams(
   use_gpu=false,
   use_position_averaging=false,
   samples_weighing_policy=CONSTANT_WEIGHT,
-  rewards_renormalization=10,
   l2_regularization=1e-4,
   optimiser=Adam(lr=5e-3),
   batch_size=64,

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -71,11 +71,11 @@ Collect samples out of a game trace and add them to the memory buffer.
 
 Here, `gamma` is the reward discount factor.
 """
-function push_trace!(mem::MemoryBuffer, trace, gamma)
+function push_trace!(mem::MemoryBuffer, trace, gamma, norm_factor)
   n = length(trace)
   wr = 0.
   for i in reverse(1:n)
-    wr = gamma * wr + trace.rewards[i]
+    wr = gamma * wr + trace.rewards[i]/norm_factor
     s = trace.states[i]
     π = trace.policies[i]
     wp = GI.white_playing(GI.init(mem.gspec, s))

--- a/src/params.jl
+++ b/src/params.jl
@@ -54,6 +54,7 @@ In the original AlphaGo Zero paper:
   dirichlet_noise_ϵ :: Float64
   dirichlet_noise_α :: Float64
   prior_temperature :: Float64 = 1.
+  adaptive_normalization :: Bool = false
 end
 
 """

--- a/src/play.jl
+++ b/src/play.jl
@@ -173,7 +173,8 @@ function MctsPlayer(
     cpuct=params.cpuct,
     noise_ϵ=params.dirichlet_noise_ϵ,
     noise_α=params.dirichlet_noise_α,
-    prior_temperature=params.prior_temperature)
+    prior_temperature=params.prior_temperature,
+    adaptive_normalization = params.adaptive_normalization)
   return MctsPlayer(mcts,
     niters=params.num_iters_per_turn,
     τ=params.temperature,
@@ -187,7 +188,8 @@ function RandomMctsPlayer(game_spec::AbstractGameSpec, params::MctsParams)
     cpuct=params.cpuct,
     gamma=params.gamma,
     noise_ϵ=params.dirichlet_noise_ϵ,
-    noise_α=params.dirichlet_noise_α)
+    noise_α=params.dirichlet_noise_α,
+    adaptive_normalization = params.adaptive_normalization)
   return MctsPlayer(mcts,
     niters=params.num_iters_per_turn,
     τ=params.temperature)

--- a/src/training.jl
+++ b/src/training.jl
@@ -269,7 +269,8 @@ end
 function self_play_measurements(trace, _, player)
   mem = MCTS.approximate_memory_footprint(player.mcts)
   edepth = MCTS.average_exploration_depth(player.mcts)
-  return (trace=trace, mem=mem, edepth=edepth)
+  norm_factor = player.mcts.norm.factor
+  return (trace=trace, mem=mem, edepth=edepth, norm_factor=norm_factor)
 end
 
 function self_play_step!(env::Env, handler)
@@ -287,7 +288,7 @@ function self_play_step!(env::Env, handler)
   # Add the collected samples in memory
   new_batch!(env.memory)
   for x in results
-    push_trace!(env.memory, x.trace, params.mcts.gamma)
+    push_trace!(env.memory, x.trace, params.mcts.gamma, x.norm_factor)
   end
   speed = cur_batch_size(env.memory) / elapsed
   edepth = mean([x.edepth for x in results])


### PR DESCRIPTION
In games with unknown reward sizes, MCTS exploration is hindered as the ratio between the Q term and the exploration therm varies. To deal with this, the rewards are scaled based on the best reward found during the search to be scaled between -1 and 1.   Likewise, the value function is scaled to learn normalized value estimations. 
The scaling is based on the maximum absolute value found so far to scale all values between -1 and 1 while keeping zero rewards at 0. 
Lastly, I'm quite new at Julia, so I'm open to suggestions on improving the code.