### PR TITLE
Use temperature adjusted MCTS policy as training target

### DIFF
--- a/src/play.jl
+++ b/src/play.jl
@@ -305,10 +305,10 @@ function play_game(gspec, player; flip_probability=0.)
     if !iszero(flip_probability) && rand() < flip_probability
       GI.apply_random_symmetry!(game)
     end
-    actions, π_target = think(player, game)
+    actions, π = think(player, game)
     τ = player_temperature(player, game, length(trace))
-    π_sample = apply_temperature(π_target, τ)
-    a = actions[Util.rand_categorical(π_sample)]
+    π_target = apply_temperature(π, τ)
+    a = actions[Util.rand_categorical(π_target)]
     GI.play!(game, a)
     push!(trace, π_target, GI.white_reward(game), GI.current_state(game))
   end


### PR DESCRIPTION
 I've been wondering about this. The way I understand the AlphaGo Zero paper is that they use the MCTS policy after applying the temperature as the training target for the policy head.
On the second page they write 

> MCTS may be viewed as a self­play algorithm that, given neural network parameters θ and a root position s, computes a vector of search probabilities recommending moves to play, π= α_θ(s), proportional to the exponentiated visit count for each move, π_a ∝ N(s, a)^1/τ, where τ is a temperature parameter.

and under figure 1b)

> [...]The neural network parameters θ are updated to maximize the similarity of the policy vector p_t to the search probabilities π_t. [...]

and figure 2d)

> Once the search is complete, search probabilities π are returned, proportional to N^1/τ, where N is the visit count of each move from the root state and τ is a parameter controlling temperature.

https://www.nature.com/articles/nature24270

Do you have a different understanding of the paper? Or was there another reason why you implemented it differently?