### PR TITLE
call batch on vectors (not generators)

### DIFF
--- a/src/learning.jl
+++ b/src/learning.jl
@@ -41,11 +41,11 @@ function convert_samples(
     es::AbstractVector{<:TrainingSample})
 
   ces = [convert_sample(gspec, wp, e) for e in es]
-  W = Flux.batch((e.w for e in ces))
-  X = Flux.batch((e.x for e in ces))
-  A = Flux.batch((e.a for e in ces))
-  P = Flux.batch((e.p for e in ces))
-  V = Flux.batch((e.v for e in ces))
+  W = Flux.batch([e.w for e in ces])
+  X = Flux.batch([e.x for e in ces])
+  A = Flux.batch([e.a for e in ces])
+  P = Flux.batch([e.p for e in ces])
+  V = Flux.batch([e.v for e in ces])
   f32(arr) = convert(AbstractArray{Float32}, arr)
   return map(f32, (; W, X, A, P, V))
 end

--- a/src/networks/network.jl
+++ b/src/networks/network.jl
@@ -306,8 +306,8 @@ MCTS oracle interface.
 """
 function evaluate_batch(nn::AbstractNetwork, batch)
   gspec = game_spec(nn)
-  X = Flux.batch((GI.vectorize_state(gspec, b) for b in batch))
-  A = Flux.batch((GI.actions_mask(GI.init(gspec, b)) for b in batch))
+  X = Flux.batch([GI.vectorize_state(gspec, b) for b in batch])
+  A = Flux.batch([GI.actions_mask(GI.init(gspec, b)) for b in batch])
   Xnet, Anet = convert_input_tuple(nn, (X, Float32.(A)))
   P, V, _ = convert_output_tuple(nn, forward_normalized(nn, Xnet, Anet))
   return [(P[A[:,i],i], V[1,i]) for i in eachindex(batch)]


### PR DESCRIPTION
The main motivation is batching states exploiting specialized implementations of `batch` that cannot be hit by a generator input. 
A specific example is the case when states are graphs for which [/GraphNeuralNetworks.jl](https://github.com/CarloLucibello/GraphNeuralNetworks.jl) defines `Flux.batch(gs::Vector{<:GNNGraph})`  

See https://github.com/CarloLucibello/GraphNeuralNetworks.jl/issues/92

cc @umbriquse @bhalonen