### PR TITLE
Allow Type Dispatch on AlphaZero.Trainer

### DIFF
--- a/src/learning.jl
+++ b/src/learning.jl
@@ -87,8 +87,8 @@ end
 ##### Trainer Utility
 #####
 
-struct Trainer
-  network :: AbstractNetwork
+struct Trainer{T} where T <: AbstractNetwork
+  network :: T
   samples :: AbstractVector{<:TrainingSample}
   params :: LearningParams
   data :: NamedTuple # (W, X, A, P, V) tuple obtained after converting `samples`
@@ -110,7 +110,7 @@ struct Trainer
     batches_stream = map(batches) do b
       Network.convert_input_tuple(network, b)
     end |> Util.cycle_iterator |> Iterators.Stateful
-    return new(network, samples, params, data, Wmean, Hp, batches_stream)
+    return new{typeof(network)}(network, samples, params, data, Wmean, Hp, batches_stream)
   end
 end
 


### PR DESCRIPTION
I've come across a use case where I need to change the functionality for batch_updates!, learning_status, and some more functions. I currently just overload the function itself, causing a warning during compilation of my package. It would be ideal if I can perform type dispatch to use the custom functions instead of overloading your functions.