### PR TITLE
Deterministic benchmarking for randomized games

### DIFF
--- a/games/connect-four/game.jl
+++ b/games/connect-four/game.jl
@@ -2,6 +2,7 @@ import AlphaZero.GI
 
 using Crayons
 using StaticArrays
+using Random: AbstractRNG
 
 const NUM_COLS = 7
 const NUM_ROWS = 6
@@ -37,7 +38,7 @@ end
 
 GI.spec(::GameEnv) = GameSpec()
 
-function GI.init(::GameSpec)
+function GI.init(::GameSpec, ::AbstractRNG)
   board = INITIAL_STATE.board
   curplayer = INITIAL_STATE.curplayer
   finished = false

--- a/games/grid-world/game.jl
+++ b/games/grid-world/game.jl
@@ -5,6 +5,7 @@
 using CommonRLInterface
 using StaticArrays
 using Crayons
+using Random: AbstractRNG
 
 const RL = CommonRLInterface
 
@@ -33,7 +34,7 @@ function World()
     0)
 end
 
-RL.reset!(env::World) = (env.state = SA[rand(1:env.size[1]), rand(1:env.size[2])])
+RL.reset!(env::World, rng::AbstractRNG) = (env.state = SA[rand(rng, 1:env.size[1]), rand(rng, 1:env.size[2])])
 RL.actions(env::World) = [SA[1,0], SA[-1,0], SA[0,1], SA[0,-1]]
 RL.observe(env::World) = env.state
 

--- a/games/grid-world/params.jl
+++ b/games/grid-world/params.jl
@@ -61,7 +61,8 @@ benchmark_sim = SimParams(
   arena.sim;
   num_games=500,
   num_workers=10,
-  batch_size=10)
+  batch_size=10,
+  deterministic=true)
 
 benchmark = [
   Benchmark.Single(

--- a/games/mancala/game.jl
+++ b/games/mancala/game.jl
@@ -2,6 +2,7 @@ import AlphaZero.GI
 
 using Crayons
 using StaticArrays
+using Random: AbstractRNG
 
 const NUM_HOUSES_PER_PLAYER = 6
 
@@ -40,7 +41,7 @@ mutable struct GameEnv <: GI.AbstractGameEnv
   finished :: Bool
 end
 
-function GI.init(::GameSpec)
+function GI.init(::GameSpec, ::AbstractRNG)
   board = INITIAL_STATE.board
   curplayer = INITIAL_STATE.curplayer
   finished = false

--- a/games/tictactoe/game.jl
+++ b/games/tictactoe/game.jl
@@ -1,4 +1,5 @@
 import AlphaZero.GI
+using Random: AbstractRNG
 using StaticArrays
 
 const BOARD_SIDE = 3
@@ -21,7 +22,7 @@ mutable struct GameEnv <: GI.AbstractGameEnv
   curplayer :: Player
 end
 
-GI.init(::GameSpec, state=INITIAL_STATE) = GameEnv(state.board, state.curplayer)
+GI.init(::GameSpec, ::AbstractRNG, state=INITIAL_STATE) = GameEnv(state.board, state.curplayer)
 
 GI.spec(::GameEnv) = GameSpec()
 

--- a/src/common_rl_intf.jl
+++ b/src/common_rl_intf.jl
@@ -6,7 +6,7 @@ module CommonRLInterfaceWrapper
 using ..AlphaZero
 import CommonRLInterface
 using Setfield
-
+using Random: AbstractRNG
 const RL = CommonRLInterface
 
 #####
@@ -119,9 +119,9 @@ GI.clone(env::Env) = @set env.rlenv = RL.clone(env.rlenv)
 
 GI.set_state!(env::Env, state) = RL.setstate!(env.rlenv, state)
 
-function GI.init(spec::Spec)
+function GI.init(spec::Spec, rng::AbstractRNG)
   env = GI.clone(spec.env)
-  RL.reset!(env.rlenv)
+  RL.reset!(env.rlenv, rng)
   return env
 end
 

--- a/src/game.jl
+++ b/src/game.jl
@@ -10,7 +10,7 @@ module GameInterface
 export AbstractGameSpec, AbstractGameEnv
 
 using ..AlphaZero: Util
-
+using Random: GLOBAL_RNG
 #####
 ##### Game environments and game specifications
 #####
@@ -43,7 +43,7 @@ Intuitively, a game environment holds a game specification and a current state.
 abstract type AbstractGameEnv end
 
 """
-    init(::AbstractGameSpec) :: AbstractGameEnv
+    init(::AbstractGameSpec, ::AbstractRNG) :: AbstractGameEnv
 
 Create a new game environment in a (possibly random) initial state.
 """
@@ -296,6 +296,8 @@ function init(gspec::AbstractGameSpec, state)
   set_state!(env, state)
   return env
 end
+
+init(gspec::AbstractGameSpec) = init(gspec, GLOBAL_RNG)
 
 #####
 ##### Derived env functions

--- a/src/params.jl
+++ b/src/params.jl
@@ -98,6 +98,7 @@ and benchmarking.
   reset_every :: Union{Nothing, Int} = 1
   flip_probability :: Float64 = 0.
   alternate_colors :: Bool = false
+  deterministic :: Bool = false
 end
 
 """

--- a/src/play.jl
+++ b/src/play.jl
@@ -1,7 +1,7 @@
 #####
 ##### Interface for players
 #####
-
+using Random: AbstractRNG, GLOBAL_RNG
 """
     AbstractPlayer
 
@@ -295,8 +295,8 @@ Simulate a game by an [`AbstractPlayer`](@ref).
   is _flipped_ randomly at every turn with probability ``p``,
   using [`GI.apply_random_symmetry!`](@ref).
 """
-function play_game(gspec, player; flip_probability=0.)
-  game = GI.init(gspec)
+function play_game(gspec, player; flip_probability=0., rng::AbstractRNG=Random.GLOBAL_RNG)
+  game = GI.init(gspec, rng)
   trace = Trace(GI.current_state(game))
   while true
     if GI.game_terminated(game)


### PR DESCRIPTION
When game environments are randomized, some instances will result in larger rewards than others, resulting in noise in the benchmarks. Using enough games can average this out, but this is inefficient for games which are slow to solve. This PR adds a random generator to the init function, which can be used to construct the environment. As the seed of the RNG is using the sim_id the same environments will be generated for each iteration benchmark. 
Ideally, the implementation influences non-randomized games as little as possible.
