### PR TITLE
Eliminate double dataload loop learning status

### DIFF
--- a/src/training.jl
+++ b/src/training.jl
@@ -223,7 +223,6 @@ function learning_step!(env::Env, handler)
     Handlers.updates_started(handler, status)
     dlosses, dttrain = @timed batch_updates!(trainer, nbatches)
     status, dtloss = @timed learning_status(trainer)
-    @show dtloss
     Handlers.updates_finished(handler, status)
     tloss += dtloss
     ttrain += dttrain

--- a/src/training.jl
+++ b/src/training.jl
@@ -223,6 +223,7 @@ function learning_step!(env::Env, handler)
     Handlers.updates_started(handler, status)
     dlosses, dttrain = @timed batch_updates!(trainer, nbatches)
     status, dtloss = @timed learning_status(trainer)
+    @show dtloss
     Handlers.updates_finished(handler, status)
     tloss += dtloss
     ttrain += dttrain


### PR DESCRIPTION
Eliminates an unnecessary dataloader loop, which can be expensive. Results in 10% improvement in gridworld problem.