### PR TITLE
feat: Implementation of GPU-friendly connect-four + tests

### DIFF
--- a/redesign/src/Tests/BitwiseConnectFourTests.jl
+++ b/redesign/src/Tests/BitwiseConnectFourTests.jl
@@ -1,0 +1,139 @@
+module BitwiseConnectFourTests
+
+    using Test
+    using ..BatchedEnvsTests
+    using ..Common.BitwiseConnectFour
+    using ...BatchedEnvs
+    using ...Util.StaticBitArrays
+
+    export run_bitwise_connect_four_tests
+
+    function run_bitwise_connect_four_tests()
+        @testset "bitwise connect-four" begin
+            test_batch_simulate(BitwiseConnectFourEnv)
+            test_gpu_friendliness(BitwiseConnectFourEnv; num_actions=7)
+            test_action_correctness()
+            test_valid_actions()
+            test_full_board()
+            test_is_win()
+            test_terminated()
+        end
+        return nothing
+    end
+
+
+    """
+    After actions [1, 2, 3, 4, 4, 3, 2, 1, 7, 7]
+    final state should looks like this
+
+    - - - - - - -         (1  -  7)  0 0 0 0 0 0 0     0 0 0 0 0 0 0  (43 - 49)
+    - - - - - - -         (8  - 14)  0 0 0 0 0 0 0     0 0 0 0 0 0 0  (50 - 56)
+    - - - - - - -  ---->  (15 - 21)  0 0 0 0 0 0 0     0 0 0 0 0 0 0  (57 - 63)
+    - - - - - - -  ---->  (22 - 28)  0 0 0 0 0 0 0     0 0 0 0 0 0 0  (64 - 70)
+    O X O X - - O         (29 - 35)  1 0 1 0 0 0 1     0 1 0 1 0 0 0  (71 - 77)
+    X O X O - - X         (36 - 42)  0 1 0 1 0 0 0     1 0 1 0 0 0 1  (78 - 84)
+
+                                     NOUGHT PLAYER     CROSS PLAYER
+    """
+    function test_action_correctness()
+        actions = [1, 2, 3, 4, 4, 3, 2, 1, 7, 7]
+        env = BitwiseConnectFourEnv()
+        for action in actions
+            env, _ = BatchedEnvs.act(env, action)
+        end
+        target_state = StaticBitArray{42 * 2, 2}()
+
+        # Nought Player
+        target_state = Base.setindex(target_state, true, 29)
+        target_state = Base.setindex(target_state, true, 31)
+        target_state = Base.setindex(target_state, true, 35)
+        target_state = Base.setindex(target_state, true, 37)
+        target_state = Base.setindex(target_state, true, 39)
+
+        # Cross Player
+        target_state = Base.setindex(target_state, true, 72)
+        target_state = Base.setindex(target_state, true, 74)
+        target_state = Base.setindex(target_state, true, 78)
+        target_state = Base.setindex(target_state, true, 80)
+        target_state = Base.setindex(target_state, true, 84)
+
+        @test env.board == target_state
+    end
+
+    function test_valid_actions()
+        env = BitwiseConnectFourEnv()
+        valid_actions = [action for action in 1:7 if BatchedEnvs.valid_action(env, action)]
+        @test valid_actions == collect(1:7)
+
+        # X and O fill the first 2 columns
+        actions = [1, 2, 2, 1, 1, 2, 2, 1, 1, 2, 2, 1]
+        for action in actions
+            env, _ = BatchedEnvs.act(env, action)
+        end
+
+        valid_actions = [action for action in 1:7 if BatchedEnvs.valid_action(env, action)]
+        @test valid_actions == collect(3:7)
+    end
+
+    function test_terminated()
+        env = BitwiseConnectFourEnv()
+        @test !BatchedEnvs.terminated(env)
+
+        # X connects-4 along main diagonal
+        actions = [1, 2, 2, 3, 3, 4, 3, 4, 4, 6, 4]
+        for action in actions
+            env, _ = BatchedEnvs.act(env, action)
+        end
+
+        @test BatchedEnvs.terminated(env)
+        @test BitwiseConnectFour.is_win(env, BitwiseConnectFour.CROSS)
+    end
+
+    function test_is_win()
+        env = BitwiseConnectFourEnv()
+        @test !BitwiseConnectFour.is_win(env, BitwiseConnectFour.CROSS)
+        @test !BitwiseConnectFour.is_win(env, BitwiseConnectFour.NOUGHT)
+
+        # 0 connects-4 along last row
+        actions = [1, 2, 2, 3, 3, 4, 3, 4, 4, 5]
+        for action in actions
+            env, _ = BatchedEnvs.act(env, action)
+        end
+
+        @test BitwiseConnectFour.is_win(env, BitwiseConnectFour.NOUGHT)
+        @test !BitwiseConnectFour.is_win(env, BitwiseConnectFour.CROSS)
+    end
+
+    function test_full_board()
+        env = BitwiseConnectFourEnv()
+        @test !BitwiseConnectFour.full_board(env)
+
+        """
+        These actions result in the following drawn board:
+
+        O O X O X X O
+        X X O X O O X
+        O O O X X X O
+        X X O X X O X
+        O O X O O O X
+        X O O X X O X
+        """
+        actions = [
+            1, 2, 4, 3, 5, 6, 7,
+            1, 3, 2, 7, 4, 1, 5,
+            2, 6, 4, 3, 5, 6, 7,
+            1, 4, 2, 5, 3, 6, 7,
+            1, 3, 2, 5, 4, 6, 7,
+            1, 3, 2, 5, 4, 6, 7
+        ]
+        for action in actions
+            env, _ = BatchedEnvs.act(env, action)
+        end
+
+        @test BatchedEnvs.terminated(env)
+        @test BitwiseConnectFour.full_board(env)
+        @test !BitwiseConnectFour.is_win(env, BitwiseConnectFour.NOUGHT)
+        @test !BitwiseConnectFour.is_win(env, BitwiseConnectFour.CROSS)
+    end
+
+end

--- a/redesign/src/Tests/Common/BitwiseConnectFour.jl
+++ b/redesign/src/Tests/Common/BitwiseConnectFour.jl
@@ -1,0 +1,122 @@
+module BitwiseConnectFour
+
+    using ....BatchedEnvs
+    using ....Util.StaticBitArrays
+
+    export BitwiseConnectFourEnv
+
+    const CROSS = true
+    const NOUGHT = false
+
+    """
+    Bitboard representation:
+
+     1 -  7  ---->   · · · · · · ·       · · · · · · ·   <---  43 - 49
+     8 - 14  ---->   · · · · · · ·       · · · · · · ·   <---  50 - 56
+    15 - 21  ---->   · · · · · · ·       · · · · · · ·   <---  57 - 63
+    22 - 28  ---->   · · · · · · ·       · · · · · · ·   <---  64 - 70
+    29 - 35  ---->   · · · · · · ·       · · · · · · ·   <---  71 - 77
+    36 - 42  ---->   · · · · · · ·       · · · · · · ·   <---  78 - 84
+
+                     NOUGHT PLAYER       CROSS PLAYER
+    """
+    const bitboard = StaticBitArray{42 * 2, 2}
+
+    """
+    A connect-four environment implemented using bitwise operations
+    that can be run on GPU.
+    """
+    struct BitwiseConnectFourEnv
+        board::bitboard
+        curplayer::Bool
+    end
+
+    function BitwiseConnectFourEnv()
+        return BitwiseConnectFourEnv(bitboard(), CROSS)
+    end
+
+    BatchedEnvs.num_actions(::BitwiseConnectFourEnv) = 7
+
+    posidx(n, player) = n + 42 * player
+    posidx(x, y, player) = posidx(7 * (x - 1) + y, player)
+
+    function Base.show(io::IO, ::MIME"text/plain", env::BitwiseConnectFourEnv)
+        for i in 1:6
+            for j in 1:7
+                if env.board[posidx(i, j, CROSS)]
+                    print(io, "X ")
+                elseif env.board[posidx(i, j, NOUGHT)]
+                    print(io, "O ")
+                else
+                    print(io, "· ")
+                end
+            end
+            println(io)
+        end
+    end
+
+    function Base.show(io::IO, env::BitwiseConnectFourEnv)
+        Base.show(io, MIME("text/plain"), env)
+    end
+
+    function BatchedEnvs.act(env::BitwiseConnectFourEnv, action)
+        at(i, j, player) = env.board[posidx(i, j, player)]
+
+        curr_row = 6
+        while at(curr_row, action, env.curplayer) ||
+              at(curr_row, action, !env.curplayer)
+            curr_row -= 1
+        end
+
+        board = Base.setindex(env.board, true, posidx(curr_row, action, env.curplayer))
+        newenv = BitwiseConnectFourEnv(board, !env.curplayer)
+        if is_win(newenv, !env.curplayer)
+            reward = -1.0
+        else
+            reward = 0.0
+        end
+
+        return newenv, (; reward, switched=true)
+    end
+
+    function BatchedEnvs.valid_action(env::BitwiseConnectFourEnv, action)
+        return begin
+            !env.board[posidx(1, action, env.curplayer)] &&
+            !env.board[posidx(1, action, !env.curplayer)]
+        end
+    end
+
+    function full_board(env::BitwiseConnectFourEnv)
+        return !any(BatchedEnvs.valid_action(env, action) for action in 1:7)
+    end
+
+    function is_win(env::BitwiseConnectFourEnv, player::Bool)
+        at(i, j) = env.board[posidx(i, j, player)]
+        for i in 1:6, j in 1:7
+            if at(i, j) == 1
+                if i <= 3 && at(i+1, j) == at(i+2, j) == at(i+3, j) == 1
+                    return true
+                end
+                if j <= 4 && at(i, j+1) == at(i, j+2) == at(i, j+3) == 1
+                    return true
+                end
+                if (i <= 3 && j <= 4) && at(i+1, j+1) == at(i+2, j+2) == at(i+3, j+3) == 1
+                    return true
+                end
+                if (i >= 4 && j <= 4) && at(i-1, j+1) == at(i-2, j+2) == at(i-3, j+3) == 1
+                    return true
+                end
+            end
+        end
+        return false
+    end
+
+    function BatchedEnvs.terminated(env::BitwiseConnectFourEnv)
+        return begin
+            is_win(env, env.curplayer) ||
+            is_win(env, !env.curplayer) ||
+            full_board(env)
+        end
+    end
+
+end

--- a/redesign/src/Tests/Common/Common.jl
+++ b/redesign/src/Tests/Common/Common.jl
@@ -5,6 +5,9 @@ using Reexport
 include("BitwiseTicTacToe.jl")
 @reexport using .BitwiseTicTacToe
 
+include("BitwiseConnectFour.jl")
+@reexport using .BitwiseConnectFour
+
 include("TestEnvs.jl")
 @reexport using .TestEnvs
 

--- a/redesign/src/Tests/Tests.jl
+++ b/redesign/src/Tests/Tests.jl
@@ -14,6 +14,9 @@ include("BatchedEnvsTests.jl")
 include("BitwiseTicTacToeTests.jl")
 @reexport using .BitwiseTicTacToeTests
 
+include("BitwiseConnectFourTests.jl")
+@reexport using .BitwiseConnectFourTests
+
 include("UtilTests.jl")
 @reexport using .UtilTests
 
@@ -30,6 +33,7 @@ function run_all_tests()
     @testset "RLZero tests" begin
         run_util_tests()
         run_bitwise_tictactoe_tests()
+        run_bitwise_connect_four_tests()
         run_mcts_tests()
         run_batched_mcts_tests()
     end


### PR DESCRIPTION
A Bitwise implementation of a GPU-friendly Connect-four environment, along with test cases for it. Specifically:


1. Added the [BitwiseConnectFour.jl](https://github.com/jonathan-laurent/AlphaZero.jl/commit/7dc506fa98e400d2370b18cd007833ff32d189f6#diff-383b1852136c9bb8f5a3bc5feb8ae21de94ff6a44b723f52e6069f925b9ad569R1) environment under `redesign/src/Tests/Common/`.
2. Added the [BitwiseConnectFourTests.jl](https://github.com/jonathan-laurent/AlphaZero.jl/commit/7dc506fa98e400d2370b18cd007833ff32d189f6#diff-7e791398b2875efab671c82331d23400de49c1998418c83ccad481b3cea727fcR1) script for testing the Bitwise Connect Four environment under `redesign/src/Tests/`.
3. Modified the [BatchEnvTests.jl](https://github.com/jonathan-laurent/AlphaZero.jl/commit/7dc506fa98e400d2370b18cd007833ff32d189f6#diff-d78dbacb2286af5ae9b8e75ab5125c2bd8ad293beea4f68672da460f6d27ff1eR114) file to add GPU-friendliness tests:
    a. Test if an environment instance is of type `isbits`.
    b. Test if an environment instance is immutable.
    c. Test to ensure that no dynamic allocations take place when environment methods are called.
    d. Test to ensure that the environment is statically inferable.
4. Modified [Common.jl](https://github.com/jonathan-laurent/AlphaZero.jl/commit/7dc506fa98e400d2370b18cd007833ff32d189f6#diff-f9ebf818738c68dedb46747b88ebbeac9bc518223d7aec578c63f5d52a9789afR8) to include and reexport the Bitwise Connect Four environment.
5. Modified [Tests.jl](https://github.com/jonathan-laurent/AlphaZero.jl/commit/7dc506fa98e400d2370b18cd007833ff32d189f6#diff-a7ef5a64afb05f81a8a8b154521a032f25032462d14a4dc91d5ef5aa1d6e4c2aR17) to include the Bitwise Connect Four tests and run them when all the tests are invoked.

All tests (3224) are passing locally.