### PR TITLE
fix: Ternary Statistics computation

### DIFF
--- a/redesign/src/Tests/BitwiseConnectFourTests.jl
+++ b/redesign/src/Tests/BitwiseConnectFourTests.jl
@@ -1,0 +1,139 @@
+module BitwiseConnectFourTests
+
+    using Test
+    using ..BatchedEnvsTests
+    using ..Common.BitwiseConnectFour
+    using ...BatchedEnvs
+    using ...Util.StaticBitArrays
+
+    export run_bitwise_connect_four_tests
+
+    function run_bitwise_connect_four_tests()
+        @testset "bitwise connect-four" begin
+            test_batch_simulate(BitwiseConnectFourEnv)
+            test_gpu_friendliness(BitwiseConnectFourEnv; num_actions=7)
+            test_action_correctness()
+            test_valid_actions()
+            test_full_board()
+            test_is_win()
+            test_terminated()
+        end
+        return nothing
+    end
+
+
+    """
+    After actions [1, 2, 3, 4, 4, 3, 2, 1, 7, 7]
+    final state should looks like this
+
+    - - - - - - -         (1  -  7)  0 0 0 0 0 0 0     0 0 0 0 0 0 0  (43 - 49)
+    - - - - - - -         (8  - 14)  0 0 0 0 0 0 0     0 0 0 0 0 0 0  (50 - 56)
+    - - - - - - -  ---->  (15 - 21)  0 0 0 0 0 0 0     0 0 0 0 0 0 0  (57 - 63)
+    - - - - - - -  ---->  (22 - 28)  0 0 0 0 0 0 0     0 0 0 0 0 0 0  (64 - 70)
+    O X O X - - O         (29 - 35)  1 0 1 0 0 0 1     0 1 0 1 0 0 0  (71 - 77)
+    X O X O - - X         (36 - 42)  0 1 0 1 0 0 0     1 0 1 0 0 0 1  (78 - 84)
+
+                                     NOUGHT PLAYER     CROSS PLAYER
+    """
+    function test_action_correctness()
+        actions = [1, 2, 3, 4, 4, 3, 2, 1, 7, 7]
+        env = BitwiseConnectFourEnv()
+        for action in actions
+            env, _ = BatchedEnvs.act(env, action)
+        end
+        target_state = StaticBitArray{42 * 2, 2}()
+
+        # Nought Player
+        target_state = Base.setindex(target_state, true, 29)
+        target_state = Base.setindex(target_state, true, 31)
+        target_state = Base.setindex(target_state, true, 35)
+        target_state = Base.setindex(target_state, true, 37)
+        target_state = Base.setindex(target_state, true, 39)
+
+        # Cross Player
+        target_state = Base.setindex(target_state, true, 72)
+        target_state = Base.setindex(target_state, true, 74)
+        target_state = Base.setindex(target_state, true, 78)
+        target_state = Base.setindex(target_state, true, 80)
+        target_state = Base.setindex(target_state, true, 84)
+
+        @test env.board == target_state
+    end
+
+    function test_valid_actions()
+        env = BitwiseConnectFourEnv()
+        valid_actions = [action for action in 1:7 if BatchedEnvs.valid_action(env, action)]
+        @test valid_actions == collect(1:7)
+
+        # X and O fill the first 2 columns
+        actions = [1, 2, 2, 1, 1, 2, 2, 1, 1, 2, 2, 1]
+        for action in actions
+            env, _ = BatchedEnvs.act(env, action)
+        end
+
+        valid_actions = [action for action in 1:7 if BatchedEnvs.valid_action(env, action)]
+        @test valid_actions == collect(3:7)
+    end
+
+    function test_terminated()
+        env = BitwiseConnectFourEnv()
+        @test !BatchedEnvs.terminated(env)
+
+        # X connects-4 along main diagonal
+        actions = [1, 2, 2, 3, 3, 4, 3, 4, 4, 6, 4]
+        for action in actions
+            env, _ = BatchedEnvs.act(env, action)
+        end
+
+        @test BatchedEnvs.terminated(env)
+        @test BitwiseConnectFour.is_win(env, BitwiseConnectFour.CROSS)
+    end
+
+    function test_is_win()
+        env = BitwiseConnectFourEnv()
+        @test !BitwiseConnectFour.is_win(env, BitwiseConnectFour.CROSS)
+        @test !BitwiseConnectFour.is_win(env, BitwiseConnectFour.NOUGHT)
+
+        # 0 connects-4 along last row
+        actions = [1, 2, 2, 3, 3, 4, 3, 4, 4, 5]
+        for action in actions
+            env, _ = BatchedEnvs.act(env, action)
+        end
+
+        @test BitwiseConnectFour.is_win(env, BitwiseConnectFour.NOUGHT)
+        @test !BitwiseConnectFour.is_win(env, BitwiseConnectFour.CROSS)
+    end
+
+    function test_full_board()
+        env = BitwiseConnectFourEnv()
+        @test !BitwiseConnectFour.full_board(env)
+
+        """
+        These actions result in the following drawn board:
+
+        O O X O X X O
+        X X O X O O X
+        O O O X X X O
+        X X O X X O X
+        O O X O O O X
+        X O O X X O X
+        """
+        actions = [
+            1, 2, 4, 3, 5, 6, 7,
+            1, 3, 2, 7, 4, 1, 5,
+            2, 6, 4, 3, 5, 6, 7,
+            1, 4, 2, 5, 3, 6, 7,
+            1, 3, 2, 5, 4, 6, 7,
+            1, 3, 2, 5, 4, 6, 7
+        ]
+        for action in actions
+            env, _ = BatchedEnvs.act(env, action)
+        end
+
+        @test BatchedEnvs.terminated(env)
+        @test BitwiseConnectFour.full_board(env)
+        @test !BitwiseConnectFour.is_win(env, BitwiseConnectFour.NOUGHT)
+        @test !BitwiseConnectFour.is_win(env, BitwiseConnectFour.CROSS)
+    end
+
+end

--- a/redesign/src/Tests/Common/BitwiseConnectFour.jl
+++ b/redesign/src/Tests/Common/BitwiseConnectFour.jl
@@ -1,0 +1,122 @@
+module BitwiseConnectFour
+
+    using ....BatchedEnvs
+    using ....Util.StaticBitArrays
+
+    export BitwiseConnectFourEnv
+
+    const CROSS = true
+    const NOUGHT = false
+
+    """
+    Bitboard representation:
+
+     1 -  7  ---->   · · · · · · ·       · · · · · · ·   <---  43 - 49
+     8 - 14  ---->   · · · · · · ·       · · · · · · ·   <---  50 - 56
+    15 - 21  ---->   · · · · · · ·       · · · · · · ·   <---  57 - 63
+    22 - 28  ---->   · · · · · · ·       · · · · · · ·   <---  64 - 70
+    29 - 35  ---->   · · · · · · ·       · · · · · · ·   <---  71 - 77
+    36 - 42  ---->   · · · · · · ·       · · · · · · ·   <---  78 - 84
+
+                     NOUGHT PLAYER       CROSS PLAYER
+    """
+    const bitboard = StaticBitArray{42 * 2, 2}
+
+    """
+    A connect-four environment implemented using bitwise operations
+    that can be run on GPU.
+    """
+    struct BitwiseConnectFourEnv
+        board::bitboard
+        curplayer::Bool
+    end
+
+    function BitwiseConnectFourEnv()
+        return BitwiseConnectFourEnv(bitboard(), CROSS)
+    end
+
+    BatchedEnvs.num_actions(::BitwiseConnectFourEnv) = 7
+
+    posidx(n, player) = n + 42 * player
+    posidx(x, y, player) = posidx(7 * (x - 1) + y, player)
+
+    function Base.show(io::IO, ::MIME"text/plain", env::BitwiseConnectFourEnv)
+        for i in 1:6
+            for j in 1:7
+                if env.board[posidx(i, j, CROSS)]
+                    print(io, "X ")
+                elseif env.board[posidx(i, j, NOUGHT)]
+                    print(io, "O ")
+                else
+                    print(io, "· ")
+                end
+            end
+            println(io)
+        end
+    end
+
+    function Base.show(io::IO, env::BitwiseConnectFourEnv)
+        Base.show(io, MIME("text/plain"), env)
+    end
+
+    function BatchedEnvs.act(env::BitwiseConnectFourEnv, action)
+        at(i, j, player) = env.board[posidx(i, j, player)]
+
+        curr_row = 6
+        while at(curr_row, action, env.curplayer) ||
+              at(curr_row, action, !env.curplayer)
+            curr_row -= 1
+        end
+
+        board = Base.setindex(env.board, true, posidx(curr_row, action, env.curplayer))
+        newenv = BitwiseConnectFourEnv(board, !env.curplayer)
+        if is_win(newenv, !env.curplayer)
+            reward = -1.0
+        else
+            reward = 0.0
+        end
+
+        return newenv, (; reward, switched=true)
+    end
+
+    function BatchedEnvs.valid_action(env::BitwiseConnectFourEnv, action)
+        return begin
+            !env.board[posidx(1, action, env.curplayer)] &&
+            !env.board[posidx(1, action, !env.curplayer)]
+        end
+    end
+
+    function full_board(env::BitwiseConnectFourEnv)
+        return !any(BatchedEnvs.valid_action(env, action) for action in 1:7)
+    end
+
+    function is_win(env::BitwiseConnectFourEnv, player::Bool)
+        at(i, j) = env.board[posidx(i, j, player)]
+        for i in 1:6, j in 1:7
+            if at(i, j) == 1
+                if i <= 3 && at(i+1, j) == at(i+2, j) == at(i+3, j) == 1
+                    return true
+                end
+                if j <= 4 && at(i, j+1) == at(i, j+2) == at(i, j+3) == 1
+                    return true
+                end
+                if (i <= 3 && j <= 4) && at(i+1, j+1) == at(i+2, j+2) == at(i+3, j+3) == 1
+                    return true
+                end
+                if (i >= 4 && j <= 4) && at(i-1, j+1) == at(i-2, j+2) == at(i-3, j+3) == 1
+                    return true
+                end
+            end
+        end
+        return false
+    end
+
+    function BatchedEnvs.terminated(env::BitwiseConnectFourEnv)
+        return begin
+            is_win(env, env.curplayer) ||
+            is_win(env, !env.curplayer) ||
+            full_board(env)
+        end
+    end
+
+end

--- a/redesign/src/Tests/Common/Common.jl
+++ b/redesign/src/Tests/Common/Common.jl
@@ -5,6 +5,9 @@ using Reexport
 include("BitwiseTicTacToe.jl")
 @reexport using .BitwiseTicTacToe
 
+include("BitwiseConnectFour.jl")
+@reexport using .BitwiseConnectFour
+
 include("TestEnvs.jl")
 @reexport using .TestEnvs
 

--- a/redesign/src/Tests/Tests.jl
+++ b/redesign/src/Tests/Tests.jl
@@ -14,6 +14,9 @@ include("BatchedEnvsTests.jl")
 include("BitwiseTicTacToeTests.jl")
 @reexport using .BitwiseTicTacToeTests
 
+include("BitwiseConnectFourTests.jl")
+@reexport using .BitwiseConnectFourTests
+
 include("UtilTests.jl")
 @reexport using .UtilTests
 
@@ -30,6 +33,7 @@ function run_all_tests()
     @testset "RLZero tests" begin
         run_util_tests()
         run_bitwise_tictactoe_tests()
+        run_bitwise_connect_four_tests()
         run_mcts_tests()
         run_batched_mcts_tests()
     end

--- a/src/benchmark.jl
+++ b/src/benchmark.jl
@@ -92,7 +92,7 @@ function run(env::Env, eval::Evaluation, progress=nothing)
   samples, elapsed = @timed simulate(
     simulator, env.gspec, eval.sim,
     game_simulated=(() -> next!(progress)))
-  gamma = env.params.self_play.mcts.gamma
+  gamma = env.params.ternary_rewards ? 1. : env.params.self_play.mcts.gamma
   rewards, redundancy = rewards_and_redundancy(samples, gamma=gamma)
   return Report.Evaluation(
     name(eval), mean(rewards), redundancy, rewards, nothing, elapsed)


### PR DESCRIPTION
This PR resolves #177 by changing the value of `gamma` when used in the `rewards_and_redudancy()` function for environments that have ternary rewards:

https://github.com/jonathan-laurent/AlphaZero.jl/blob/66eaed8e4d8f60f8d535d949e5447b5c5f821ee8/src/simulations.jl#L292

Specifically, the changes that have been made are:

1. In the [`run()`](https://github.com/AndrewSpano/AlphaZero.jl/blob/fb212c9170c9c13fd8cd1abb4580b099bb5fd481/src/benchmark.jl#L78) function of [benchmark.jl](https://github.com/AndrewSpano/AlphaZero.jl/blob/fb212c9170c9c13fd8cd1abb4580b099bb5fd481/src/benchmark.jl), the following line was produced to check if the current environment has ternary rewards, and if yes then `gamma == 1` is used for the [`report.Evaluation`](https://github.com/AndrewSpano/AlphaZero.jl/blob/fb212c9170c9c13fd8cd1abb4580b099bb5fd481/src/report.jl#L73) rewards:

    `gamma = env.params.ternary_rewards ? 1. : env.params.self_play.mcts.gamma`

2. In [training.jl](https://github.com/AndrewSpano/AlphaZero.jl/blob/fb212c9170c9c13fd8cd1abb4580b099bb5fd481/src/training.jl), the functions
    - [`pit_networks()`](https://github.com/AndrewSpano/AlphaZero.jl/blob/fb212c9170c9c13fd8cd1abb4580b099bb5fd481/src/training.jl#L130)
    - [`evaluate_network()`](https://github.com/AndrewSpano/AlphaZero.jl/blob/fb212c9170c9c13fd8cd1abb4580b099bb5fd481/src/training.jl#L146)
    - [`compare_networks()`](https://github.com/AndrewSpano/AlphaZero.jl/blob/fb212c9170c9c13fd8cd1abb4580b099bb5fd481/src/training.jl#L159)

    now take the extra argument `eval_gamma` that is used to compute the rewards in `rewards_and_redudancy()`. This value is computed in [`learning_step!()`](https://github.com/AndrewSpano/AlphaZero.jl/blob/fb212c9170c9c13fd8cd1abb4580b099bb5fd481/src/training.jl#L195), [before](https://github.com/AndrewSpano/AlphaZero.jl/blob/fb212c9170c9c13fd8cd1abb4580b099bb5fd481/src/training.jl#L240) `compare_networks()` is invoked:

    ```julia
      eval_gamma = env.params.ternary_rewards ? 1. : env.params.self_play.mcts.gamma
      eval_report =
        compare_networks(env.gspec, env.curnn, env.bestnn, ap, handler, eval_gamma)
    ```

