### PR TITLE
fix: Ternary Statistics computation

### DIFF
--- a/src/benchmark.jl
+++ b/src/benchmark.jl
@@ -92,7 +92,7 @@ function run(env::Env, eval::Evaluation, progress=nothing)
   samples, elapsed = @timed simulate(
     simulator, env.gspec, eval.sim,
     game_simulated=(() -> next!(progress)))
-  gamma = env.params.self_play.mcts.gamma
+  gamma = env.params.ternary_rewards ? 1. : env.params.self_play.mcts.gamma
   rewards, redundancy = rewards_and_redundancy(samples, gamma=gamma)
   return Report.Evaluation(
     name(eval), mean(rewards), redundancy, rewards, nothing, elapsed)


### PR DESCRIPTION
This PR resolves #177 by changing the value of `gamma` when used in the `rewards_and_redudancy()` function for environments that have ternary rewards:

https://github.com/jonathan-laurent/AlphaZero.jl/blob/66eaed8e4d8f60f8d535d949e5447b5c5f821ee8/src/simulations.jl#L292

Specifically, the changes that have been made are:

1. In the [`run()`](https://github.com/AndrewSpano/AlphaZero.jl/blob/fb212c9170c9c13fd8cd1abb4580b099bb5fd481/src/benchmark.jl#L78) function of [benchmark.jl](https://github.com/AndrewSpano/AlphaZero.jl/blob/fb212c9170c9c13fd8cd1abb4580b099bb5fd481/src/benchmark.jl), the following line was produced to check if the current environment has ternary rewards, and if yes then `gamma == 1` is used for the [`report.Evaluation`](https://github.com/AndrewSpano/AlphaZero.jl/blob/fb212c9170c9c13fd8cd1abb4580b099bb5fd481/src/report.jl#L73) rewards:

    `gamma = env.params.ternary_rewards ? 1. : env.params.self_play.mcts.gamma`

2. In [training.jl](https://github.com/AndrewSpano/AlphaZero.jl/blob/fb212c9170c9c13fd8cd1abb4580b099bb5fd481/src/training.jl), the functions
    - [`pit_networks()`](https://github.com/AndrewSpano/AlphaZero.jl/blob/fb212c9170c9c13fd8cd1abb4580b099bb5fd481/src/training.jl#L130)
    - [`evaluate_network()`](https://github.com/AndrewSpano/AlphaZero.jl/blob/fb212c9170c9c13fd8cd1abb4580b099bb5fd481/src/training.jl#L146)
    - [`compare_networks()`](https://github.com/AndrewSpano/AlphaZero.jl/blob/fb212c9170c9c13fd8cd1abb4580b099bb5fd481/src/training.jl#L159)

    now take the extra argument `eval_gamma` that is used to compute the rewards in `rewards_and_redudancy()`. This value is computed in [`learning_step!()`](https://github.com/AndrewSpano/AlphaZero.jl/blob/fb212c9170c9c13fd8cd1abb4580b099bb5fd481/src/training.jl#L195), [before](https://github.com/AndrewSpano/AlphaZero.jl/blob/fb212c9170c9c13fd8cd1abb4580b099bb5fd481/src/training.jl#L240) `compare_networks()` is invoked:

    ```julia
      eval_gamma = env.params.ternary_rewards ? 1. : env.params.self_play.mcts.gamma
      eval_report =
        compare_networks(env.gspec, env.curnn, env.bestnn, ap, handler, eval_gamma)
    ```


Note: Raising an error if the environment has ternary rewards and `mcts.gamma < 1`, does not make much sense. Having `gamma < 1` will result in MCTS weighing more trajectories that lead quicker to higher rewards. E.g. in chess, if there are only ternary rewards, two sequences that lead to checkmate will have the same reward. This may not be the desired behavior, as a user may prefer the shorter trajectory. For `gamma < 1` the cumulative reward of shorter trajectories will be higher than for longer ones.